### PR TITLE
fix directories property value map name

### DIFF
--- a/lib/swagger_client/models/directories_property_value_map.rb
+++ b/lib/swagger_client/models/directories_property_value_map.rb
@@ -24,7 +24,7 @@ module SwaggerClient
     def self.attribute_map
       {
         :'id' => :'ID',
-        :'name' => :'NAME',
+        :'name' => :'Name',
         :'directory_type' => :'directory_type'
       }
     end


### PR DESCRIPTION
The api returns the property value as "Name" and not "NAME" this is why we were unable to retrieve the value in the wrapper 
