### PR TITLE
[SST-19155] Fix rails logger from capturing error

### DIFF
--- a/lib/swagger_client/api_client.rb
+++ b/lib/swagger_client/api_client.rb
@@ -62,10 +62,17 @@ module SwaggerClient
           fail ApiError.new(:code => 0,
                             :message => response.return_message)
         else
-          fail ApiError.new(:code => response.code,
-                            :response_headers => response.headers,
-                            :response_body => response.body),
-               response.status_message
+          # When status message is not present the logger is not printing the ApiError. This conditional allows the error to be captured.
+          if response.status_message.present?
+            fail ApiError.new(:code => response.code,
+                              :response_headers => response.headers,
+                              :response_body => response.body),
+                 response.status_message
+          else
+            fail ApiError.new(:code => response.code,
+                              :response_headers => response.headers,
+                              :response_body => response.body)
+          end
         end
       end
 


### PR DESCRIPTION
### JIRA: ###

https://tractionguest.atlassian.net/browse/SST-19155

### Description: ###

Note: When I talked to scottie he said that this tool was generated from a CLI Tool called Swagger Client. 

Currently when we log an error from the lenel-sdk on traction-guest-server our logs are populating like:
FAILED TO COMPLETE BADGE CREATION: ""
Nothing is captured from the ApiError.
In debugging the issue, I found that the status_message on the response was not present, causing the message to be nothing. 
I have added a conditional to remove the status_message check. With that change you will see something like this in the rails logging: 
FAILED TO COMPLETE BADGE CREATION: {:code=>500, :response_headers=>{"access-control-allow-headers"=>"Application-Id, Session-Token, DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Content-Length", "access-control-allow-methods"=>"GET, POST, PUT, DELETE, OPTIONS", "content-type"=>"application/json", "date"=>"Wed, 06 Apr 2022 22:20:42 GMT", "strict-transport-security"=>"max-age=31536000; includeSubDomains"}, :response_body=>"{\"error\":{\"code\":\"openaccess.editinstance.error\",\"message\":\"wpBadgeMapper.cpp(916): The person already has the maximum number of active badges.\"},\"version\":\"1.0\"}"}

Doing this will allow us to debug errors as we are getting the reason why the badge creation failed.

### PR Checklist ###

- [ ] Assigned 2 or more reviewers
- [ ] Added yourself as "Assignee"
- [ ] Included labels such as "WIP", "Waiting for reviews", etc.
- [ ] Desk-check done
